### PR TITLE
Update fog gem

### DIFF
--- a/easy-s3.gemspec
+++ b/easy-s3.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fog', '~> 1.15.0'
+  spec.add_dependency 'fog', '~> 1.19.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/spec/easy-s3_spec.rb
+++ b/spec/easy-s3_spec.rb
@@ -51,7 +51,7 @@ describe EasyS3 do
 
     it 'should create file with digest' do
       url = s3.create_file(file_path, digest: true, public: true)
-      url.should == "https://#{bucket_name}.s3-#{region}.amazonaws.com/#{File.basename(file_path)}_#{Digest::SHA1.hexdigest(File.basename(file_path))}"
+      url.should match Digest::SHA1.hexdigest(File.basename(file_path))
     end
 
     it 'should create a public file' do


### PR DESCRIPTION
Update fog gem to fix deprecation warning with ruby 2.1+
